### PR TITLE
feat: run auto-translate on feature branch

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -2,7 +2,7 @@ name: Auto Translate
 
 on:
   push:
-    branches: [dev]
+    branches: [dev, feature/multilingual-docs]
     paths:
       - 'packages/web/src/content/docs/docs/*.mdx'
       - 'packages/web/src/content/docs/docs/*.md'


### PR DESCRIPTION
## Summary
- trigger auto-translate workflow on feature/multilingual-docs branch

## Testing
- `bun run typecheck` *(fails: Cannot find module '@opencode-ai/sdk' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68bc38a80fd48333b0e1abc9c4a682a5