### PR TITLE
fix: checkout triggering branch in auto-translate workflow

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -4,29 +4,29 @@ on:
   push:
     branches: [dev, feature/multilingual-docs]
     paths:
-      - 'packages/web/src/content/docs/docs/*.mdx'
-      - 'packages/web/src/content/docs/docs/*.md'
+      - "packages/web/src/content/docs/docs/*.mdx"
+      - "packages/web/src/content/docs/docs/*.md"
 
 jobs:
   translate:
     runs-on: ubuntu-latest
     permissions:
-      contents: write      # Need write permission for creating branches, commits, etc.
-      id-token: write     # Generate JWT token for GitHub API calls
+      contents: write # Need write permission for creating branches, commits, etc.
+      id-token: write # Generate JWT token for GitHub API calls
       pull-requests: write # Need write permission for creating pull requests
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: dev
-          fetch-depth: 0  # Need full history to detect changes
-          
+          ref: ${{ github.ref_name }}
+          fetch-depth: 0 # Need full history to detect changes
+
       - name: Run translation
         uses: ./auto-translate
         with:
           model: anthropic/claude-sonnet-4-20250514
-          source_lang: 'en'
-          target_lang: 'zh'
+          source_lang: "en"
+          target_lang: "zh"
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- use github.ref_name to checkout triggering branch in auto-translate workflow

## Testing
- `bun run typecheck` (fails: Cannot find module 'node:child_process', '@tsconfig/node22' not found)

Links back to #<当前PR号>.

------
https://chatgpt.com/codex/tasks/task_e_68bc40a356708333a08e1b796f5cf64a